### PR TITLE
Rewrite Star Rating Component.

### DIFF
--- a/scss/react-star-rating.scss
+++ b/scss/react-star-rating.scss
@@ -12,6 +12,7 @@
 	span.star {
 		width: 100%;
 		text-align: center;
+		cursor: pointer;
 	}
 	span.rating-number {
 		font-size: 24px;

--- a/scss/react-star-rating.scss
+++ b/scss/react-star-rating.scss
@@ -1,4 +1,15 @@
-.rating-container, .react-star-rating__root{
-  vertical-align:middle;display:inline-block
+.star-rated-outline:before {
+  color: #ccc;
 }
-.rating-container .rating-stars:before,.rating-container:before{content:attr(data-content)}.react-star-rating__star{width:25px}.react-star-rating__star #star-flat{fill:#C6C6C6}.react-star-rating__star #star-flat:hover{fill:#FFA91B}.react-star-rating__root{font-size:2em}.react-star-rating__root.rating-editing:hover{cursor:pointer}.rating-container{position:relative;color:#e3e3e3;overflow:hidden}.rating-container .rating-stars{position:absolute;left:0;top:0;white-space:nowrap;overflow:hidden;color:#F5A71B;-webkit-transition:all .01s;-moz-transition:all .01s;transition:all .01s;-webkit-mask-image:-webkit-gradient(linear,left top,left bottom,from(#FDBD47),to(#F5A71B))}.react-rating-caption{font-size:1.25em;vertical-align:middle;margin-right:.5em}.rating-disabled .rating-container:hover{cursor:not-allowed}.react-star-rating__size--sm{font-size:1em}.react-star-rating__size--md{font-size:2em}.react-star-rating__size--lg{font-size:2.5em}
+.star-rated {
+  color: #f1a545;
+}
+
+.star-container {
+	display: flex;
+	justify-content: space-evenly;
+	span.star {
+		width: 100%;
+		text-align: center;
+	}
+}

--- a/scss/react-star-rating.scss
+++ b/scss/react-star-rating.scss
@@ -8,8 +8,14 @@
 .star-container {
 	display: flex;
 	justify-content: space-evenly;
+	align-items: center;
 	span.star {
 		width: 100%;
 		text-align: center;
+	}
+	span.rating-number {
+		font-size: 24px;
+		display: inline-block;
+		min-width: 50px;
 	}
 }

--- a/src/star-rating.jsx
+++ b/src/star-rating.jsx
@@ -38,6 +38,12 @@ export default class StarRating extends React.Component {
   }
 
   handleMouseout() {
+    const { disabled } = this.props;
+
+    if (disabled) {
+      return;
+    }
+
     this.setState(prev => ({
       rating: prev.temp_rating
     }));

--- a/src/star-rating.jsx
+++ b/src/star-rating.jsx
@@ -22,12 +22,18 @@ export default class StarRating extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      rating: this.props.rating || 0,
+      rating: props.rating || 0,
       temp_rating: 0
     };
   }
 
   handleMouseover(rating) {
+    const { disabled } = this.props;
+
+    if (disabled) {
+      return;
+    }
+
     this.setState(prev => ({
       rating,
       temp_rating: prev.rating
@@ -41,16 +47,25 @@ export default class StarRating extends React.Component {
   }
 
   rate(rating) {
+    const { onRatingClick, disabled } = this.props;
+
+    if (disabled) {
+      return;
+    }
+
     this.setState({
       rating,
       temp_rating: rating
     });
+
+    onRatingClick(rating);
   }
 
   render() {
+    const { ratingAmount, name } = this.props;
     const { rating } = this.state;
     let stars = [];
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < ratingAmount; i++) {
       let starClass = "star-rated-outline";
       const isValidRating = rating >= i+0.5 && rating !== 0;
       if (isValidRating) {
@@ -65,7 +80,10 @@ export default class StarRating extends React.Component {
       }
 
       stars.push(
-        <span className="star" key={`star-${i+0.5}`}>
+        <span
+          className="star" key={`star-${i+0.5}`}
+          name={name}
+        >
           <span
             style={{
               ...starStyles,

--- a/src/star-rating.jsx
+++ b/src/star-rating.jsx
@@ -8,12 +8,9 @@ import cx from 'classnames';
  * Referenced from https://codesandbox.io/s/oq6l8ppon9
  * <StarRating
  *   name={string} - name for form input (required)
- *   caption={string} - caption for rating (optional)
- *   ratingAmount={number} - the rating amount (required, default: 5)
  *   rating={number} - a set rating between the rating amount (optional)
  *   disabled={boolean} - whether to disable the rating from being selected (optional)
  *   editing={boolean} - whether the rating is explicitly in editing mode (optional)
- *   size={string} - size of stars (optional)
  *   onRatingClick={function} - a handler function that gets called onClick of the rating (optional)
  *   />
  */
@@ -62,10 +59,13 @@ export default class StarRating extends React.Component {
   }
 
   render() {
-    const { ratingAmount, name } = this.props;
+    const { name } = this.props;
     const { rating } = this.state;
+
+    // Restricted to 5 stars.
+    const RATING_AMOUNT = 5;
     let stars = [];
-    for (let i = 0; i < ratingAmount; i++) {
+    for (let i = 0; i < RATING_AMOUNT; i++) {
       let starClass = "star-rated-outline";
       const isValidRating = rating >= i+0.5 && rating !== 0;
       if (isValidRating) {
@@ -119,19 +119,14 @@ export default class StarRating extends React.Component {
 
 StarRating.propTypes = {
   name: PropTypes.string.isRequired,
-  caption: PropTypes.string,
-  ratingAmount: PropTypes.number.isRequired,
   rating: PropTypes.number,
   onRatingClick: PropTypes.func,
   disabled: PropTypes.bool,
   editing: PropTypes.bool,
-  size: PropTypes.string,
 };
 
 StarRating.defaultProps = {
-  step: 0.5,
   rating: 0,
-  ratingAmount: 5,
   onRatingClick() {},
   disabled: false,
 };

--- a/src/star-rating.jsx
+++ b/src/star-rating.jsx
@@ -111,7 +111,10 @@ export default class StarRating extends React.Component {
     }
     return (
       <div className="rating-stars">
-        <div className="star-container">{stars}</div>
+        <div className="star-container">
+        {stars}
+        <span className="rating-number">{rating}</span>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Rewrite the Star Component for more accessibility to style stars.
Code Referenced from [React Star Rating](https://codesandbox.io/s/oq6l8ppon9)

With more accessibility to stars, The star rating container width can be controlled from CSS.
**BEFORE**
<img width="623" alt="Screenshot 2019-04-01 at 5 24 46 PM" src="https://user-images.githubusercontent.com/22497932/55325574-26de0e00-54a3-11e9-99d3-60e3c14c79f2.png">

**AFTER**
The following screenshot shows the star rating occupied in full width by default.
<img width="626" alt="Screenshot 2019-04-01 at 6 19 24 PM" src="https://user-images.githubusercontent.com/22497932/55328744-baffa380-54aa-11e9-978c-f92c37105a39.png">

