### PR TITLE
Dependencies Conflict Fixes and Minor Helper Text Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2938,26 +2938,6 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
-    "draft-js": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
-      "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
-      "requires": {
-        "fbjs": "^0.8.15",
-        "immutable": "~3.7.4",
-        "object-assign": "^4.1.0"
-      }
-    },
-    "draftjs-to-html": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/draftjs-to-html/-/draftjs-to-html-0.6.3.tgz",
-      "integrity": "sha1-gMet4VF9F7HGVBeBHx0Wp1H+GnA="
-    },
-    "draftjs-utils": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.9.4.tgz",
-      "integrity": "sha512-KYjABSbGpJrwrwmxVj5UhfV37MF/p0QRxKIyL+/+QOaJ8J9z1FBKxkblThbpR0nJi9lxPQWGg+gh+v0dAsSCCg=="
-    },
     "duplexify": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
@@ -3971,7 +3951,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3992,12 +3973,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4012,17 +3995,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4139,7 +4125,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4151,6 +4138,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4165,6 +4153,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4172,12 +4161,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4196,6 +4187,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4276,7 +4268,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4288,6 +4281,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4373,7 +4367,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4409,6 +4404,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4428,6 +4424,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4471,12 +4468,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4592,6 +4591,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -4844,11 +4844,6 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
-    },
-    "html-to-draftjs": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.4.0.tgz",
-      "integrity": "sha1-ijy7ultJ1QvozoXMCLES1b8A/B0="
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -5308,11 +5303,6 @@
         "invariant": "^2.2.0"
       }
     },
-    "immutable": {
-      "version": "3.7.6",
-      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
-    },
     "import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -5698,7 +5688,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5723,6 +5714,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -6021,14 +6013,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "linkify-it": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-      "requires": {
-        "uc.micro": "^1.0.1"
       }
     },
     "load-json-file": {
@@ -8134,18 +8118,6 @@
         "prop-types": "^15.6.0"
       }
     },
-    "react-draft-wysiwyg": {
-      "version": "1.12.13",
-      "resolved": "https://registry.npmjs.org/react-draft-wysiwyg/-/react-draft-wysiwyg-1.12.13.tgz",
-      "integrity": "sha1-YJv5kYYHg3IjtniTseQNWOIDQfQ=",
-      "requires": {
-        "classnames": "^2.2.5",
-        "draftjs-utils": "^0.9.3",
-        "html-to-draftjs": "^1.4.0",
-        "linkify-it": "^2.0.3",
-        "prop-types": "^15.6.0"
-      }
-    },
     "react-input-autosize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
@@ -9921,11 +9893,6 @@
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
       "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-    },
-    "uc.micro": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "uglify-es": {
       "version": "3.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cb-react-form-builder",
-  "version": "0.1.53",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cb-react-form-builder",
-  "version": "0.1.42",
+  "version": "0.1.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   "author": "Codebrahma",
   "dependencies": {
     "classnames": "^2.2.5",
-    "draft-js": "^0.10.0",
-    "draftjs-to-html": "^0.6.1",
     "es6-promise": "^4.2.4",
     "fbemitter": "^2.1.1",
     "immutability-helper": "^2.6.6",
@@ -36,7 +34,6 @@
     "react-datepicker": "^1.7.0",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
-    "react-draft-wysiwyg": "^1.12.13",
     "react-select": "^2.4.2",
     "react-signature-canvas": "^1.0.0-alpha.1",
     "react-textarea-autosize": "^6.0.0",
@@ -44,7 +41,10 @@
   },
   "peerDependencies": {
     "react": "16.3.x",
-    "react-dom": "16.3.x"
+    "react-dom": "16.3.x",
+    "draft-js": "^0.10.0",
+    "draftjs-to-html": "^0.6.1",
+    "react-draft-wysiwyg": "^1.12.13"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cb-react-form-builder",
-  "version": "0.1.53",
+  "version": "0.2.0",
   "description": "A complete form builder for react.",
   "main": "lib/index.js",
   "license": "MIT",

--- a/src/form-place-holder.jsx
+++ b/src/form-place-holder.jsx
@@ -21,6 +21,6 @@ PlaceHolder.propTypes = {
 };
 
 PlaceHolder.defaultProps = {
-  text: 'Select/Drop an item from toolbox',
+  text: 'Click to Add or Drop an item from the toolbox',
   show: false,
 };


### PR DESCRIPTION
Moved `draft-js`, `draftjs-to-html` and `react-draft-wysiwyg` to peer dependencies

**IMPORTANT NOTE**:
This is no longer supported for usage in other projects, customized for mentor app in many ways - use the non-customized actual package for other projects